### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ You can find connector settings in `settings.py` file
 
 ## Run
 ```
-pyhton worker.py
+python worker.py
 ```


### PR DESCRIPTION
\# typo
pyhton worker.py

\# fixed
python worker.py

\# I use on my Ubuntu 15.10 to run: 
python3.5 worker.py 
